### PR TITLE
Parallelize stack detection

### DIFF
--- a/src/domain/stack.rs
+++ b/src/domain/stack.rs
@@ -22,14 +22,6 @@ pub(crate) trait Stack: Display {
 pub(crate) struct Stacks(Vec<Box<dyn Stack>>);
 
 impl Stacks {
-  pub(crate) fn new() -> Self {
-    Self(vec![])
-  }
-
-  pub(crate) fn push(&mut self, stack: Box<dyn Stack>) {
-    self.0.push(stack);
-  }
-
   /// provides all the tasks from all stacks that match the given task name
   pub(crate) fn tasks_fuzzy_matching_name(&self, name: &str) -> Vec<&Task> {
     let matcher = SkimMatcherV2::default();
@@ -43,6 +35,12 @@ impl Stacks {
     }
     search_results.sort();
     search_results.into_iter().map(|sr| sr.task).collect()
+  }
+}
+
+impl From<Vec<Box<dyn Stack>>> for Stacks {
+  fn from(value: Vec<Box<dyn Stack>>) -> Self {
+    Stacks(value)
   }
 }
 

--- a/src/stacks/makefile.rs
+++ b/src/stacks/makefile.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::io::ErrorKind;
 use std::process::Command;
 
-pub(crate) struct MakefileStack {
+struct MakefileStack {
   tasks: Tasks,
 }
 
@@ -31,7 +31,7 @@ impl Stack for MakefileStack {
   }
 }
 
-pub(crate) fn scan() -> Option<MakefileStack> {
+pub(crate) fn scan() -> Option<Box<dyn Stack>> {
   let text = match fs::read_to_string("Makefile") {
     Ok(text) => text,
     Err(e) => match e.kind() {
@@ -42,9 +42,9 @@ pub(crate) fn scan() -> Option<MakefileStack> {
       }
     },
   };
-  Some(MakefileStack {
+  Some(Box::new(MakefileStack {
     tasks: parse_text(&text),
-  })
+  }))
 }
 
 /// provides the tasks in the given Makefile content

--- a/src/stacks/makefile.rs
+++ b/src/stacks/makefile.rs
@@ -1,4 +1,4 @@
-use crate::domain::{Stack, Stacks, Task, Tasks};
+use crate::domain::{Stack, Task, Tasks};
 use big_s::S;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -7,7 +7,7 @@ use std::fs;
 use std::io::ErrorKind;
 use std::process::Command;
 
-struct MakefileStack {
+pub(crate) struct MakefileStack {
   tasks: Tasks,
 }
 
@@ -31,20 +31,20 @@ impl Stack for MakefileStack {
   }
 }
 
-pub(crate) fn scan(stacks: &mut Stacks) {
+pub(crate) fn scan() -> Option<MakefileStack> {
   let text = match fs::read_to_string("Makefile") {
     Ok(text) => text,
     Err(e) => match e.kind() {
-      ErrorKind::NotFound => return,
+      ErrorKind::NotFound => return None,
       e => {
         println!("Warning: Cannot read file \"Makefile\": {e}");
-        return;
+        return None;
       }
     },
   };
-  stacks.push(Box::new(MakefileStack {
+  Some(MakefileStack {
     tasks: parse_text(&text),
-  }));
+  })
 }
 
 /// provides the tasks in the given Makefile content

--- a/src/stacks/mod.rs
+++ b/src/stacks/mod.rs
@@ -10,11 +10,23 @@ use std::env;
 
 /// determines the existing stacks
 pub(crate) fn load() -> Stacks {
-  let mut result = Stacks::new();
   let cwd = env::current_dir().unwrap();
-  makefile::scan(&mut result);
-  node_npm::scan(&mut result, &cwd);
-  node_yarn::scan(&mut result, &cwd);
-  rust_cargo::scan(&mut result);
+  let make_stack = makefile::scan();
+  let node_npm_stack = node_npm::scan(&cwd);
+  let node_yarn_stack = node_yarn::scan(&cwd);
+  let rust_stack = rust_cargo::scan();
+  let mut result = Stacks::new();
+  if let Some(stack) = make_stack {
+    result.push(Box::new(stack));
+  }
+  if let Some(stack) = node_npm_stack {
+    result.push(Box::new(stack));
+  }
+  if let Some(stack) = node_yarn_stack {
+    result.push(Box::new(stack));
+  }
+  if let Some(stack) = rust_stack {
+    result.push(Box::new(stack));
+  }
   result
 }

--- a/src/stacks/mod.rs
+++ b/src/stacks/mod.rs
@@ -5,28 +5,18 @@ mod node_npm;
 mod node_yarn;
 mod rust_cargo;
 
-use crate::domain::Stacks;
+use crate::domain::{Stack, Stacks};
 use std::env;
 
 /// determines the existing stacks
 pub(crate) fn load() -> Stacks {
   let cwd = env::current_dir().unwrap();
-  let make_stack = makefile::scan();
-  let node_npm_stack = node_npm::scan(&cwd);
-  let node_yarn_stack = node_yarn::scan(&cwd);
-  let rust_stack = rust_cargo::scan();
-  let mut result = Stacks::new();
-  if let Some(stack) = make_stack {
-    result.push(Box::new(stack));
-  }
-  if let Some(stack) = node_npm_stack {
-    result.push(Box::new(stack));
-  }
-  if let Some(stack) = node_yarn_stack {
-    result.push(Box::new(stack));
-  }
-  if let Some(stack) = rust_stack {
-    result.push(Box::new(stack));
-  }
-  result
+  let stacks = vec![
+    makefile::scan(),
+    node_npm::scan(&cwd),
+    node_yarn::scan(&cwd),
+    rust_cargo::scan(),
+  ];
+  let stacks: Vec<Box<dyn Stack>> = stacks.into_iter().flatten().collect();
+  Stacks::from(stacks)
 }

--- a/src/stacks/node_npm.rs
+++ b/src/stacks/node_npm.rs
@@ -8,7 +8,7 @@ use std::io::{BufReader, ErrorKind};
 use std::path::Path;
 use std::process::Command;
 
-pub(crate) struct NodeNpmStack {
+struct NodeNpmStack {
   tasks: Tasks,
 }
 

--- a/src/stacks/node_npm.rs
+++ b/src/stacks/node_npm.rs
@@ -39,7 +39,7 @@ pub(crate) struct PackageJson {
   pub(crate) scripts: Option<HashMap<String, String>>,
 }
 
-pub(crate) fn scan(mut dir: &Path) -> Option<NodeNpmStack> {
+pub(crate) fn scan(mut dir: &Path) -> Option<Box<dyn Stack>> {
   if !Path::new("package.json").exists() {
     return None;
   }
@@ -47,9 +47,9 @@ pub(crate) fn scan(mut dir: &Path) -> Option<NodeNpmStack> {
   loop {
     let lockfile = dir.join("package-lock.json");
     if lockfile.exists() {
-      return Some(NodeNpmStack {
+      return Some(Box::new(NodeNpmStack {
         tasks: parse_scripts(package_json),
-      });
+      }));
     }
     match dir.parent() {
       Some(parent) => dir = parent,

--- a/src/stacks/node_npm.rs
+++ b/src/stacks/node_npm.rs
@@ -1,4 +1,4 @@
-use crate::domain::{Stack, Stacks, Task, Tasks};
+use crate::domain::{Stack, Task, Tasks};
 use big_s::S;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -8,7 +8,7 @@ use std::io::{BufReader, ErrorKind};
 use std::path::Path;
 use std::process::Command;
 
-struct NodeNpmStack {
+pub(crate) struct NodeNpmStack {
   tasks: Tasks,
 }
 
@@ -39,24 +39,21 @@ pub(crate) struct PackageJson {
   pub(crate) scripts: Option<HashMap<String, String>>,
 }
 
-pub(crate) fn scan(stacks: &mut Stacks, mut dir: &Path) {
+pub(crate) fn scan(mut dir: &Path) -> Option<NodeNpmStack> {
   if !Path::new("package.json").exists() {
-    return;
+    return None;
   }
-  let Some(package_json) = load_package_json() else {
-    return;
-  };
+  let package_json = load_package_json()?;
   loop {
     let lockfile = dir.join("package-lock.json");
     if lockfile.exists() {
-      stacks.push(Box::new(NodeNpmStack {
+      return Some(NodeNpmStack {
         tasks: parse_scripts(package_json),
-      }));
-      return;
+      });
     }
     match dir.parent() {
       Some(parent) => dir = parent,
-      None => return,
+      None => return None,
     }
   }
 }

--- a/src/stacks/node_yarn.rs
+++ b/src/stacks/node_yarn.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use std::path::Path;
 use std::process::Command;
 
-pub(crate) struct NodeYarnStack {
+struct NodeYarnStack {
   tasks: Tasks,
 }
 

--- a/src/stacks/node_yarn.rs
+++ b/src/stacks/node_yarn.rs
@@ -1,11 +1,11 @@
 use super::node_npm::{PackageJson, load_package_json};
-use crate::domain::{Stack, Stacks, Task, Tasks};
+use crate::domain::{Stack, Task, Tasks};
 use big_s::S;
 use std::fmt::Display;
 use std::path::Path;
 use std::process::Command;
 
-struct NodeYarnStack {
+pub(crate) struct NodeYarnStack {
   tasks: Tasks,
 }
 
@@ -31,21 +31,18 @@ impl Stack for NodeYarnStack {
   }
 }
 
-pub(crate) fn scan(stacks: &mut Stacks, mut dir: &Path) {
-  let Some(package_json) = load_package_json() else {
-    return;
-  };
+pub(crate) fn scan(mut dir: &Path) -> Option<NodeYarnStack> {
+  let package_json = load_package_json()?;
   loop {
     let yarn_lock = dir.join("yarn.lock");
     if yarn_lock.exists() {
-      stacks.push(Box::new(NodeYarnStack {
+      return Some(NodeYarnStack {
         tasks: parse_scripts(package_json),
-      }));
-      return;
+      });
     }
     match dir.parent() {
       Some(parent) => dir = parent,
-      None => return,
+      None => return None,
     }
   }
 }

--- a/src/stacks/node_yarn.rs
+++ b/src/stacks/node_yarn.rs
@@ -31,14 +31,14 @@ impl Stack for NodeYarnStack {
   }
 }
 
-pub(crate) fn scan(mut dir: &Path) -> Option<NodeYarnStack> {
+pub(crate) fn scan(mut dir: &Path) -> Option<Box<dyn Stack>> {
   let package_json = load_package_json()?;
   loop {
     let yarn_lock = dir.join("yarn.lock");
     if yarn_lock.exists() {
-      return Some(NodeYarnStack {
+      return Some(Box::new(NodeYarnStack {
         tasks: parse_scripts(package_json),
-      });
+      }));
     }
     match dir.parent() {
       Some(parent) => dir = parent,

--- a/src/stacks/ruby_bundler.rs
+++ b/src/stacks/ruby_bundler.rs
@@ -1,4 +1,4 @@
-use crate::domain::{Stack, Stacks, Task, Tasks};
+use crate::domain::{Stack, Task, Tasks};
 use big_s::S;
 use std::fmt::Display;
 use std::path::Path;
@@ -30,12 +30,13 @@ impl Stack for RubyBundlerStack {
   }
 }
 
-pub(crate) fn scan(stacks: &mut Stacks) {
+pub(crate) fn scan() -> Option<Box<dyn Stack>> {
   if Path::new("Gemfile").exists() && Path::new("Rakefile").exists() {
-    stacks.push(Box::new(RubyBundlerStack {
+    return Some(Box::new(RubyBundlerStack {
       tasks: parse_task_list(&load_tasks()),
     }));
   }
+  None
 }
 
 fn load_tasks() -> String {

--- a/src/stacks/rust_cargo.rs
+++ b/src/stacks/rust_cargo.rs
@@ -1,9 +1,9 @@
-use crate::domain::{Stack, Stacks, Tasks};
+use crate::domain::{Stack, Tasks};
 use std::fmt::Display;
 use std::path::Path;
 use std::process::Command;
 
-struct RustCargoStack {
+pub(crate) struct RustCargoStack {
   tasks: Tasks,
 }
 
@@ -29,10 +29,11 @@ impl Stack for RustCargoStack {
   }
 }
 
-pub(crate) fn scan(stacks: &mut Stacks) {
+pub(crate) fn scan() -> Option<RustCargoStack> {
   if Path::new("Cargo.toml").exists() {
-    stacks.push(Box::new(RustCargoStack {
+    return Some(RustCargoStack {
       tasks: Tasks::new(),
-    }));
+    });
   }
+  None
 }

--- a/src/stacks/rust_cargo.rs
+++ b/src/stacks/rust_cargo.rs
@@ -29,11 +29,11 @@ impl Stack for RustCargoStack {
   }
 }
 
-pub(crate) fn scan() -> Option<RustCargoStack> {
+pub(crate) fn scan() -> Option<Box<dyn Stack>> {
   if Path::new("Cargo.toml").exists() {
-    return Some(RustCargoStack {
+    return Some(Box::new(RustCargoStack {
       tasks: Tasks::new(),
-    });
+    }));
   }
   None
 }

--- a/src/stacks/rust_cargo.rs
+++ b/src/stacks/rust_cargo.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use std::path::Path;
 use std::process::Command;
 
-pub(crate) struct RustCargoStack {
+struct RustCargoStack {
   tasks: Tasks,
 }
 


### PR DESCRIPTION
Writing to the mutable parameter forces serialization. This PR allows optimizations that load all stacks in parallel.

Also removes unnecessary mutability.